### PR TITLE
Set error to undefined when executing mutation

### DIFF
--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -84,7 +84,12 @@ export function useMutation<Data>(mutation: IMutation<Data> | Mutation<Data>): M
     container,
     storage,
     mutator,
-    onStatusChanged: (x) => setStatus(x),
+    onStatusChanged: (x) => {
+      if (x === MutationStatus.Executing) {
+        setError(undefined);
+      }
+      setStatus(x);
+    },
     onError: (err) => setError(err),
   });
 


### PR DESCRIPTION
Addresses the issue below:
When the user triggers an error during a mutation, error gets defined. After the error gets rectified, error is still defined inappropriately